### PR TITLE
GDA-3488 Generate debug symbols to a file called targetname.PDB, so t…

### DIFF
--- a/libcurl_vs2013.vcxproj
+++ b/libcurl_vs2013.vcxproj
@@ -110,6 +110,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <PreBuildEvent>
       <Command>copy include\curl\curlbuild_win.h include\curl\curlbuild.h</Command>
@@ -147,6 +148,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <PreBuildEvent>
       <Command>copy include\curl\curlbuild_win.h include\curl\curlbuild.h</Command>


### PR DESCRIPTION
…hat the symbols can be archived for later.
